### PR TITLE
Feature/api path refinement

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -14,8 +14,8 @@ on:
 env:
   ## Sets environment variable
   BACKEND_DIRECTORY: app_backend
-  PUBLISH_PROFILE: ${{ secrets.PIXELFORPEACE_PUBLISH_PROFILE }}
-  APP_NAME: pixelforpeace-api
+  PUBLISH_PROFILE: ${{ secrets.BACKEND_PUBLISH_PROFILE }}
+  APP_NAME: pixelsforpeace-api
   SLOT_NAME: Production
   ENV_FILE: ${{ secrets.ENV_FILE }}
 

--- a/app_backend/src/main.ts
+++ b/app_backend/src/main.ts
@@ -20,7 +20,7 @@ async function bootstrap() {
     .setVersion('1.0')
     .build()
   const document = SwaggerModule.createDocument(app, config)
-  SwaggerModule.setup('api', app, document, {
+  SwaggerModule.setup('', app, document, {
     swaggerOptions: {
       apisSorter: 'alpha',
       tagsSorter: 'alpha',

--- a/app_backend/src/sale/create-sale.dto.ts
+++ b/app_backend/src/sale/create-sale.dto.ts
@@ -12,7 +12,8 @@ export class CreateSaleDto {
   readonly description: string
   readonly recipient: Recipient
   readonly closing_time: Date
-  readonly bet_price: string
-  readonly highestBid: string
+  readonly bet_price: number
+  readonly starting_bid: number
+  readonly highest_bid: number
   readonly image_ipfs_url: string
 }

--- a/app_backend/src/sale/create-sale.dto.ts
+++ b/app_backend/src/sale/create-sale.dto.ts
@@ -5,7 +5,6 @@ class Recipient {
 }
 
 export class CreateSaleDto {
-  _id: string
   readonly sale_contract_addr: string
   readonly name_of_sale: string
   readonly type_of_sale: string

--- a/app_backend/src/sale/sale.interface.ts
+++ b/app_backend/src/sale/sale.interface.ts
@@ -14,7 +14,8 @@ export interface Sale extends Document {
   readonly description: string
   readonly recipient: Recipient
   readonly closing_time: Date
-  readonly bet_price: string
-  readonly highestBid: string
+  readonly bet_price: number
+  readonly starting_bid: number
+  readonly highest_bid: number
   readonly image_ipfs_url: string
 }

--- a/app_backend/src/sale/sale.interface.ts
+++ b/app_backend/src/sale/sale.interface.ts
@@ -7,7 +7,6 @@ export interface Recipient extends Document {
 }
 
 export interface Sale extends Document {
-  _id: string
   readonly sale_contract_addr: string
   readonly name_of_sale: string
   readonly type_of_sale: string

--- a/app_backend/src/sale/sale.schema.ts
+++ b/app_backend/src/sale/sale.schema.ts
@@ -14,7 +14,8 @@ export const SaleSchema = new mongoose.Schema({
   description: String,
   recipient: RecipientSchema,
   closing_time: Date,
-  bet_price: String,
-  highestBid: String,
+  bet_price: Number,
+  starting_bid: Number,
+  highest_bid: Number,
   image_ipfs_url: String,
 })

--- a/app_backend/src/sale/sale.schema.ts
+++ b/app_backend/src/sale/sale.schema.ts
@@ -1,21 +1,26 @@
 import * as mongoose from 'mongoose'
 
-export const RecipientSchema = new mongoose.Schema({
-  recipient_name: String,
-  recipient_desc: String,
-  recipient_addr: String,
-})
+export const RecipientSchema = new mongoose.Schema(
+  {
+    recipient_name: String,
+    recipient_desc: String,
+    recipient_addr: String,
+  },
+  { versionKey: false },
+)
 
-export const SaleSchema = new mongoose.Schema({
-  _id: String,
-  sale_contract_addr: String,
-  name_of_sale: String,
-  type_of_sale: String,
-  description: String,
-  recipient: RecipientSchema,
-  closing_time: Date,
-  bet_price: Number,
-  starting_bid: Number,
-  highest_bid: Number,
-  image_ipfs_url: String,
-})
+export const SaleSchema = new mongoose.Schema(
+  {
+    sale_contract_addr: String,
+    name_of_sale: String,
+    type_of_sale: String,
+    description: String,
+    recipient: RecipientSchema,
+    closing_time: Date,
+    bet_price: Number,
+    starting_bid: Number,
+    highest_bid: Number,
+    image_ipfs_url: String,
+  },
+  { versionKey: false },
+)

--- a/app_backend/src/sale/sales.controller.ts
+++ b/app_backend/src/sale/sales.controller.ts
@@ -4,7 +4,7 @@ import { CreateSaleDto } from './create-sale.dto'
 import { Sale } from './sale.interface'
 import { ApiOperation } from '@nestjs/swagger'
 
-@Controller('sales')
+@Controller('api/sales')
 export class SalesController {
   constructor(private readonly salesService: SalesService) {}
 

--- a/app_backend/src/sale/sales.controller.ts
+++ b/app_backend/src/sale/sales.controller.ts
@@ -10,7 +10,7 @@ export class SalesController {
 
   @Get(':id')
   @ApiOperation({
-    description: 'Return a specific sale given a sale contract address.',
+    description: 'Return a specific sale given an _id',
   })
   async findOne(@Param('id') id: string): Promise<Sale> {
     return this.salesService.findOne(id)
@@ -24,18 +24,23 @@ export class SalesController {
 
   @Post()
   @ApiOperation({
-    description:
-      'Add a single sale document to the database with contract address as _id',
+    description: 'Add a single sale document to the database.',
   })
   async create(@Body() createSaleDto: CreateSaleDto) {
-    createSaleDto._id = createSaleDto.sale_contract_addr
     await this.salesService.create(createSaleDto)
   }
 
-  @Put(':id')
-  @ApiOperation({ description: 'Update any sale document given an _id.' })
-  async update(@Param('id') id: string, @Body() updateSaleDto: CreateSaleDto) {
-    return await this.salesService.update(id, updateSaleDto)
+  @Put(':filter')
+  @ApiOperation({
+    description:
+      'Update any sale document given a json to use as a matching filter.',
+  })
+  async update(
+    @Param('filter') filter: string,
+    @Body() updateSaleDto: CreateSaleDto,
+  ) {
+    const filterObj: CreateSaleDto = JSON.parse(filter)
+    return await this.salesService.update(filterObj, updateSaleDto)
   }
 
   @Delete(':id')

--- a/app_backend/src/sale/sales.service.ts
+++ b/app_backend/src/sale/sales.service.ts
@@ -21,9 +21,9 @@ export class SalesService {
     return this.saleModel.findOne({ _id: id }).exec()
   }
 
-  async update(id: string, updateSaleDto: CreateSaleDto) {
+  async update(filter: CreateSaleDto, updateSaleDto: CreateSaleDto) {
     return await this.saleModel
-      .findOneAndUpdate({ id }, updateSaleDto, {
+      .findOneAndUpdate(filter, updateSaleDto, {
         new: true,
       })
       .exec()


### PR DESCRIPTION
- New publish profile to deploy to pixelsforpeace instead of pixelforpeace.
- SwaggerUI default to root domain. 
- bid and price fields in JSON sale data are now appropriately number type.
- Manual _id and _v fields are removed. PUT update api call uses JSON object as filter. 